### PR TITLE
Work around https://gitlab.com/DavidGriffith/frotz/-/issues/287

### DIFF
--- a/src/common/screen.c
+++ b/src/common/screen.c
@@ -973,11 +973,6 @@ void z_draw_picture(void)
 
 	int i;
 
-	if (f_setup.blorb_file == NULL) {
-		runtime_error(ERR_PICTURE_MISSING);
-		f_setup.err_report_repeat = ERR_PICTURE_MISSING;
-	}
-
 	flush_buffer();
 
 	if (y == 0)		/* use cursor line if y-coordinate is 0 */


### PR DESCRIPTION
This fixes the bug we see in PR https://github.com/curiousdannii/infocom-frotz/pull/16

In https://gitlab.com/DavidGriffith/frotz/-/issues/279 I requested that we add a warning message if the user forgets to provide a blorb file. It's gone through a few iterations, and now it's causing https://gitlab.com/DavidGriffith/frotz/-/issues/287

I'm working around the issue here by simply not logging the warning. (We won't miss it, because anyone using this branch hopefully knows what they're doing.)